### PR TITLE
Limit scope of replacement of variables to text nodes only

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -108,7 +108,6 @@ export function decorateMain(main) {
   buildAutoBlocks(main);
   decorateSections(main);
   decorateBlocks(main);
-  getDataByCustomerId(main);
 }
 
 /**
@@ -124,6 +123,7 @@ async function loadEager(doc) {
     document.body.classList.add('appear');
     await loadSection(main.querySelector('.section'), waitForFirstImage);
   }
+  getDataByCustomerId(main);
   try {
     /* if desktop (proxy for fast connection) or fonts already loaded, load fonts.css */
     if (window.innerWidth >= 900 || sessionStorage.getItem('fonts-loaded')) {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -92,7 +92,7 @@ export async function getDataByCustomerId() {
   const textNodes = getTextNodes(main);
 
   // Replace placeholders in each text node
-  textNodes.forEach(node => {
+  textNodes.forEach((node) => {
     let text = node.nodeValue;
     Object.entries(replacements).forEach(([key, value]) => {
       text = text.replaceAll(`{${key}}`, value);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -122,8 +122,9 @@ async function loadEager(doc) {
     decorateMain(main);
     document.body.classList.add('appear');
     await loadSection(main.querySelector('.section'), waitForFirstImage);
+    await getDataByCustomerId(main);
   }
-  getDataByCustomerId(main);
+
   try {
     /* if desktop (proxy for fast connection) or fonts already loaded, load fonts.css */
     if (window.innerWidth >= 900 || sessionStorage.getItem('fonts-loaded')) {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -53,13 +53,14 @@ async function fetchCustomerData(customerId) {
     const rows = Array.isArray(data) ? data : data.rows || data.data || [];
     const customerRow = rows.find((row) => row.customer_id === customerId);
     if (customerRow) {
-      console.log('Customer data found:', customerRow);
       hasFetchedCustomerData = true;
       return customerRow;
     }
+    // eslint-disable-next-line no-console
     console.log(`No data found for customer ID: ${customerId}`);
     return null;
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.error('Error fetching customer data:', error);
     return null;
   }


### PR DESCRIPTION
Thanks to a tip from Josh, this update:
- Only updates text content (not HTML structure)
- Avoids breaking event listeners or scripts
- Is more robust and less error-prone
- I can add it back to decorate(main)

Test URLs:
- Before: https://main--frequent-alerters--aemsites.aem.page/customer-data/charitytest
- After: https://charity-test--frequent-alerters--aemsites.aem.page/customer-data/charitytest

This page shouldn't break:
- Before: https://main--frequent-alerters--aemsites.aem.page/
- After: https://charity-test--frequent-alerters--aemsites.aem.page/
